### PR TITLE
resolve #23 Postモデルテストの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 yarn-debug.log*
 .yarn-integrity
 .env
+.vscode

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry-rails'
   gem 'rspec-rails'
+  gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,13 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
+    faker (2.19.0)
+      i18n (>= 1.6, < 2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -309,6 +316,8 @@ DEPENDENCIES
   compass-rails
   devise
   dotenv-rails
+  factory_bot_rails
+  faker
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.2)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,10 +2,15 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
 
+  before_save :add_date_to_text
   after_save :start_slack_sync
 
   validates :text, presence: true, length: { maximum: 255 }
   validates :image, format: /\A#{URI::regexp(%w(http https))}\z/, allow_blank: true
+
+  def add_date_to_text
+    self.text += " :#{self.user&.nickname}の投稿" if self.text.present?
+  end
 
   def start_slack_sync
     Resque.enqueue(SlackSyncJobs, self.class.name, self.id)

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module App
     config.time_zone = 'Tokyo'
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.yml').to_s]
+    Faker::Config.locale = :en
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/resque.yml
+++ b/config/resque.yml
@@ -1,2 +1,3 @@
 redis:
   development: redis:6379
+  test: redis:6379

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :comment do
+    text {Faker::Lorem.sentence}
+  end
+end

--- a/spec/factories/post.rb
+++ b/spec/factories/post.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :post do
+    text {Faker::Lorem.sentence}
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    nickname {Faker::Lorem.unique.characters(number:10)}
+    email {Faker::Internet.free_email(name: nickname)}
+    password {Faker::Internet.password(min_length: 6)}
+    password_confirmation {password}
+  end
+end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe Post do
+  let(:user) { create(:user) }
+  let(:post) { build(:post, user_id: user.id) }
+
+  context 'validationテスト' do
+    it '正常チェック' do
+      expect(post.save).to be_truthy
+    end
+
+    it 'textは必須' do
+      post.text = nil
+      expect(post.save).to be_falsey
+      post.text = ""
+      expect(post.save).to be_falsey
+    end
+
+    it 'textは255文字以内で保存できる' do
+      post.text = Faker::Lorem.characters(number: 255)
+      expect(post.save).to be_truthy
+    end
+
+    it 'textは256文字以上で保存できない' do
+      post.text = Faker::Lorem.characters(number: 256)
+      expect(post.save).to be_falsey
+    end
+
+    it 'imageはurl形式で保存できる' do
+      post.image = Faker::Internet.url(scheme: 'http')
+      expect(post.save).to be_truthy
+      post.image = Faker::Internet.url(scheme: 'https')
+      expect(post.save).to be_truthy
+    end
+
+    it 'imageはurl形式以外で保存できない' do
+      post.image = Faker::Lorem.word
+      expect(post.save).to be_falsey
+    end
+  end
+
+  context '投稿内容' do
+    it '投稿が意図した内容で保存される' do
+      post.text = "投稿内容テスト"
+      post.save
+      expect(post.text).to eq("投稿内容テスト :#{post.user.nickname}の投稿")
+    end
+  end
+end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -3,47 +3,80 @@ require 'rails_helper'
 describe Post do
   let(:user) { create(:user) }
   let(:post) { build(:post, user_id: user.id) }
+  subject { post.save }
 
-  context 'validationテスト' do
-    it '正常チェック' do
-      expect(post.save).to be_truthy
+  describe 'validationテスト' do
+    context '正常チェック' do
+      it '保存できること' do
+        is_expected.to eq(true)
+      end
     end
 
-    it 'textは必須' do
-      post.text = nil
-      expect(post.save).to be_falsey
-      post.text = ""
-      expect(post.save).to be_falsey
+    context 'text' do
+      it 'nilの場合、保存できない' do
+        post.text = nil
+        is_expected.to eq(false)
+      end
+
+      it '空文字の場合、保存できない' do
+        post.text = ""
+        is_expected.to eq(false)
+      end
+
+      it '255文字以内の場合、保存できる' do
+        post.text = Faker::Lorem.characters(number: 255)
+        is_expected.to eq(true)
+      end
+
+      it '256文字以上の場合、保存できない' do
+        post.text = Faker::Lorem.characters(number: 256)
+        is_expected.to eq(false)
+      end
     end
 
-    it 'textは255文字以内で保存できる' do
-      post.text = Faker::Lorem.characters(number: 255)
-      expect(post.save).to be_truthy
+    context 'image' do
+      it 'url形式の場合、保存できる' do
+        post.image = Faker::Internet.url(scheme: 'http')
+        is_expected.to eq(true)
+        post.image = Faker::Internet.url(scheme: 'https')
+        is_expected.to eq(true)
+      end
+
+      it 'url形式以外の場合、保存できない' do
+        post.image = Faker::Lorem.word
+        is_expected.to eq(false)
+      end
     end
 
-    it 'textは256文字以上で保存できない' do
-      post.text = Faker::Lorem.characters(number: 256)
-      expect(post.save).to be_falsey
-    end
+    context 'user_id' do
+      it 'nilの場合、保存できない' do
+        post.user_id = nil
+        is_expected.to eq(false)
+      end
 
-    it 'imageはurl形式で保存できる' do
-      post.image = Faker::Internet.url(scheme: 'http')
-      expect(post.save).to be_truthy
-      post.image = Faker::Internet.url(scheme: 'https')
-      expect(post.save).to be_truthy
-    end
-
-    it 'imageはurl形式以外で保存できない' do
-      post.image = Faker::Lorem.word
-      expect(post.save).to be_falsey
+      it '存在しないUserのidの場合、保存できない' do
+        # TODO:存在しないUserのidの取得方法の検討
+        post.user_id = User.maximum(:id) + 1
+        is_expected.to eq(false)
+      end
     end
   end
 
-  context '投稿内容' do
-    it '投稿が意図した内容で保存される' do
-      post.text = "投稿内容テスト"
-      post.save
-      expect(post.text).to eq("投稿内容テスト :#{post.user.nickname}の投稿")
+  describe '投稿機能' do
+    context '#add_date_to_text' do
+      it '意図した投稿内容になっているか' do
+        post.text = "投稿内容テスト"
+        subject
+        expect(post.text).to eq("投稿内容テスト :#{post.user.nickname}の投稿")
+      end
+    end
+
+    context '削除' do
+      let!(:comment){ post.comments.build({text: "comment_text", user_id: user.id}) }
+      it '投稿を削除した時、それに紐づくCommentも削除される' do
+        subject
+        expect{ post.destroy }.to change(Comment,:count).by(-1)
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,66 @@
+# This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'spec_helper'
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+# Prevent database truncation if the environment is production
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'rspec/rails'
+# Add additional requires below this line. Rails is not loaded until this point!
+
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+#
+# The following line is provided for convenience purposes. It has the downside
+# of increasing the boot-up time by auto-requiring all files in the support
+# directory. Alternatively, in the individual `*_spec.rb` files, manually
+# require only the support files necessary.
+#
+# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+
+# Checks for pending migrations and applies them before tests are run.
+# If you are not using ActiveRecord, you can remove these lines.
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
+RSpec.configure do |config|
+  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+
+  # If you're not using ActiveRecord, or you'd prefer not to run each of your
+  # examples within a transaction, remove the following line or assign false
+  # instead of true.
+  config.use_transactional_fixtures = true
+
+  # You can uncomment this line to turn off ActiveRecord support entirely.
+  # config.use_active_record = false
+
+  # RSpec Rails can automatically mix in different behaviours to your tests
+  # based on their file location, for example enabling you to call `get` and
+  # `post` in specs under `spec/controllers`.
+  #
+  # You can disable this behaviour by removing the line below, and instead
+  # explicitly tag your specs with their type, e.g.:
+  #
+  #     RSpec.describe UsersController, type: :controller do
+  #       # ...
+  #     end
+  #
+  # The different available types are documented in the features, such as in
+  # https://relishapp.com/rspec/rspec-rails/docs
+  config.infer_spec_type_from_file_location!
+
+  # Filter lines from Rails gems in backtraces.
+  config.filter_rails_from_backtrace!
+  # arbitrary gems may also be filtered via:
+  # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end


### PR DESCRIPTION
## What
- Postモデルにおけるバリデーションテスト、意図したデータになるかのテストを実装
- Factorybotを導入
- Fakerの導入
- User、Postモデルのデモデータを用意

## Why
- Postモデルのデータ制御の信頼性を高めるため