### PR TITLE
resolve #24 Userモデルのテスト実装

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   has_many :comments
 
   validates :nickname, presence: true, uniqueness: true, length: { maximum: 10 }
+  validates :password_confirmation, presence: true
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -183,7 +183,11 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # デフォルト
+  # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  # 記号/全角などを除く
+  config.email_regexp = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+describe User do
+  let(:user) { build(:user) }
+  subject { user.save }
+
+  describe 'validationテスト' do
+    context '正常チェック' do
+      it '保存できること' do
+        is_expected.to eq(true)
+      end
+    end
+
+    context 'nickname' do
+      it 'nilの場合、保存できない' do
+        user.nickname = nil
+        is_expected.to eq(false)
+      end
+
+      it '空文字の場合、保存できない' do
+        user.nickname = ""
+        is_expected.to eq(false)
+      end
+
+      it '10文字以内の場合、保存できる' do
+        user.nickname = Faker::Lorem.unique.characters(number: 10)
+        is_expected.to eq(true)
+      end
+
+      it '11文字以上の場合、保存できない' do
+        user.nickname = Faker::Lorem.unique.characters(number: 11)
+        is_expected.to eq(false)
+      end
+
+      it 'すでに使用されているnicknameの場合、保存できない' do
+        subject
+        next_user = build(:user, nickname: user.nickname)
+        expect(next_user.save).to eq(false)
+      end
+    end
+
+    context 'email' do
+      it 'nilの場合、保存できない' do
+        user.email = nil
+        is_expected.to eq(false)
+      end
+
+      it '空文字の場合、保存できない' do
+        user.email = ""
+        is_expected.to eq(false)
+      end
+
+      it 'emailの形式ではない場合、保存できない' do
+        user.email = Faker::Lorem.sentence
+        is_expected.to eq(false)
+      end
+
+      it '全角文字を使用する場合、保存できない' do
+        user.email = 'ｅｘａｐｌｅ@gmail.com'
+        is_expected.to eq(false)
+      end
+
+      it 'すでに使用されているemailの場合、保存できない' do
+        subject
+        next_user = build(:user, email: user.email)
+        expect(next_user.save).to eq(false)
+      end
+    end
+
+    context 'password' do
+      it 'passwordがnilの場合、保存できない' do
+        user.password = nil
+        is_expected.to eq(false)
+      end
+
+      it 'passwordが空文字の場合、保存できない' do
+        user.password = ""
+        is_expected.to eq(false)
+      end
+
+      it 'password_confirmationがnilの場合、保存できない' do
+        user.password_confirmation = nil
+        is_expected.to eq(false)
+      end
+
+      it 'password_confirmationが空文字の場合、保存できない' do
+        user.password_confirmation = ""
+        is_expected.to eq(false)
+      end
+
+      it 'passwordとpassword_confirmationが不一致の場合、保存できない' do
+        user.password = 'password'
+        user.password_confirmation = 'password_confirmation'
+        is_expected.to eq(false)
+      end
+
+      it '5文字以下の場合、保存できない' do
+        user.password = user.password_confirmation = Faker::Lorem.characters(number: 5)
+        is_expected.to eq(false)
+      end
+
+      it '6文字以上、128文字以下の場合、保存できる' do
+        user.password = user.password_confirmation = Faker::Lorem.characters(number: 6)
+        is_expected.to eq(true)
+        user.password = user.password_confirmation = Faker::Lorem.characters(number: 128)
+        is_expected.to eq(true)
+      end
+
+      it '129文字以上の場合、保存できない' do
+        user.password = user.password_confirmation = Faker::Lorem.characters(number: 129)
+        is_expected.to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What
- Userモデルのテストを実装
- deviseのemailのバリデーションが初期状態だと記号や全角等も受け入れてしまっていたため、変更
- password_confirmationがnilの場合、userが保存できてしまっていたため、バリデーションを追加

## Why
- Userのデータ制御の信頼性を担保するため