### PR TITLE
resolve #27 slack連携テストの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'webmock'
+  gem 'vcr'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,7 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
+    vcr (6.0.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
     warden (1.2.9)
@@ -343,6 +344,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   tzinfo-data
+  vcr
   web-console (>= 3.3.0)
   webdrivers
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     compass-rails (2.0.1)
       compass (~> 1.0.0)
     concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -115,6 +117,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -292,6 +295,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (4.3.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -338,6 +345,7 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 3.3.0)
   webdrivers
+  webmock
   webpacker (~> 4.0)
   whenever
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,5 +2,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative 'config/application'
+require 'resque/tasks'
+task 'resque:setup' => :environment
 
 Rails.application.load_tasks

--- a/app/jobs/slack_sync_jobs.rb
+++ b/app/jobs/slack_sync_jobs.rb
@@ -1,10 +1,8 @@
-class SlackSyncJobs
-  @queue = :slack_sync_jobs
+class SlackSyncJobs < ApplicationJob
+  queue_as :slack_sync_jobs
 
-  class << self
-    def perform(model_type, id)
-      model = model_type.constantize.find(id)
-      model.slack_sync!
-    end
+  def perform(model_type, id)
+    model = model_type.constantize.find(id)
+    model.slack_sync!
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -13,7 +13,7 @@ class Post < ApplicationRecord
   end
 
   def start_slack_sync
-    Resque.enqueue(SlackSyncJobs, self.class.name, self.id)
+    SlackSyncJobs.perform_later(self.class.name, self.id)
   end
 
   def slack_sync!

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ module App
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.yml').to_s]
     Faker::Config.locale = :en
+    config.active_job.queue_adapter = :resque
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,6 @@ Rails.application.routes.draw do
   end
   resources :users, only: [:show]
 
-  mount Resque::Server.new, :at => "/resque"
+  mount Resque::Server, at: '/jobs'
 
 end

--- a/spec/job/slack_sync_jobs_spec.rb
+++ b/spec/job/slack_sync_jobs_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Post do
+  let(:post) { create(:post, user: create(:user)) }
+  subject { SlackSyncJobs.perform(post.class.name, post.id) }
+
+  context '' do
+    before do
+      allow(post.class.name.constantize).to receive(:find).with(post.id).and_return(post)
+      allow(post).to receive(:slack_sync!)
+    end
+
+    it '適切にメソッドを呼び出しているか' do
+      subject
+      expect(post.class.name.constantize).to have_received(:find).with(post.id)
+      expect(post).to have_received(:slack_sync!)
+    end
+  end
+end

--- a/spec/job/slack_sync_jobs_spec.rb
+++ b/spec/job/slack_sync_jobs_spec.rb
@@ -1,19 +1,29 @@
 require 'rails_helper'
 
-describe Post do
+describe SlackSyncJobs do
+  include ActiveJob::TestHelper
   let(:post) { create(:post, user: create(:user)) }
-  subject { SlackSyncJobs.perform(post.class.name, post.id) }
+  subject { SlackSyncJobs.perform_now(post.class.name, post.id) }
 
-  context '' do
+  context '#perform' do
     before do
       allow(post.class.name.constantize).to receive(:find).with(post.id).and_return(post)
       allow(post).to receive(:slack_sync!)
     end
 
-    it '適切にメソッドを呼び出しているか' do
+    it 'sholud call the appropriate method' do
       subject
       expect(post.class.name.constantize).to have_received(:find).with(post.id)
       expect(post).to have_received(:slack_sync!)
+    end
+  end
+
+  context 'post to slack' do
+    ActiveJob::Base.queue_adapter = :test
+    it 'should job has been queued', :vcr do
+      expect {
+        SlackSyncJobs.perform_later(post.class.name, post.id)
+      }.to have_enqueued_job(SlackSyncJobs).with('Post', post.id)
     end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -78,5 +78,15 @@ describe Post do
         expect{ post.destroy }.to change(Comment,:count).by(-1)
       end
     end
+
+    context '#start_slack_sync' do
+      before do
+        allow(SlackSyncJobs).to receive(:perform_later)
+      end
+      it '保存した時にメソッドを呼び出しているか' do
+        subject
+        expect(SlackSyncJobs).to have_received(:perform_later).with(post.class.name, post.id)
+      end
+    end
   end
 end

--- a/spec/service/send_post_service_spec.rb
+++ b/spec/service/send_post_service_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe Slack::SendPostService do
+  describe 'slack alignment' do
+    context "#send_post" do
+      it 'post to slack', :vcr do
+        response = Slack::SendPostService.new('user_nickname').send_post('test_message')
+        expect(response.first.message).to eq("OK")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'vcr'
+require 'webmock'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -8,4 +11,10 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/vcr'
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
 end

--- a/spec/vcr/Slack_SendPostService/slack_alignment/_send_post/post_to_slack.yml
+++ b/spec/vcr/Slack_SendPostService/slack_alignment/_send_post/post_to_slack.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 23 Feb 2022 02:50:47 GMT
+      - Wed, 23 Feb 2022 11:13:13 GMT
       Server:
       - Apache
       X-Powered-By:
@@ -43,16 +43,16 @@ http_interactions:
       Content-Type:
       - text/html
       X-Envoy-Upstream-Service-Time:
-      - '173'
+      - '179'
       X-Backend:
       - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
         main_control_with_overflow main_bedrock_control_with_overflow
       X-Server:
-      - slack-www-hhvm-main-iad-fjlq
+      - slack-www-hhvm-main-iad-9wbu
       X-Slack-Shared-Secret-Outcome:
       - no-match
       Via:
-      - envoy-www-iad-p8ci, envoy-edge-nrt-qejf
+      - envoy-www-iad-2nfw, envoy-edge-nrt-0bmx
       X-Edge-Backend:
       - envoy-www
       X-Slack-Edge-Shared-Secret-Outcome:
@@ -60,5 +60,5 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: ok
-  recorded_at: Wed, 23 Feb 2022 02:50:47 GMT
+  recorded_at: Wed, 23 Feb 2022 11:13:13 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/Slack_SendPostService/slack_alignment/_slack_sync_/post_to_slack.yml
+++ b/spec/vcr/Slack_SendPostService/slack_alignment/_slack_sync_/post_to_slack.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://hooks.slack.com/services/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
+    body:
+      encoding: US-ASCII
+      string: payload=%7B%22channel%22%3A%22%23testpost%22%2C%22username%22%3A%22user_nickname%22%2C%22text%22%3A%22test_message%22%7D
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 23 Feb 2022 02:50:47 GMT
+      Server:
+      - Apache
+      X-Powered-By:
+      - HHVM/4.128.0
+      X-Frame-Options:
+      - SAMEORIGIN
+      Access-Control-Allow-Origin:
+      - "*"
+      Referrer-Policy:
+      - no-referrer
+      X-Slack-Backend:
+      - r
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Content-Length:
+      - '22'
+      Content-Type:
+      - text/html
+      X-Envoy-Upstream-Service-Time:
+      - '173'
+      X-Backend:
+      - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
+        main_control_with_overflow main_bedrock_control_with_overflow
+      X-Server:
+      - slack-www-hhvm-main-iad-fjlq
+      X-Slack-Shared-Secret-Outcome:
+      - no-match
+      Via:
+      - envoy-www-iad-p8ci, envoy-edge-nrt-qejf
+      X-Edge-Backend:
+      - envoy-www
+      X-Slack-Edge-Shared-Secret-Outcome:
+      - no-match
+    body:
+      encoding: ASCII-8BIT
+      string: ok
+  recorded_at: Wed, 23 Feb 2022 02:50:47 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## What
- slack連携テストの実装
- jobの単体テスト（メソッドを呼び出しているか、キューに登録できているかなど）
- SendPostServiceのテスト実装

## Why
- slack連携機能の信頼性の担保のため