### PR TITLE
resolve #11 comment controllerテストの実装

### DIFF
--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe CommentsController, type: :controller do
+  describe '#create' do
+    let(:user) { create(:user) }
+    let(:post_instance) { create(:post, user: user) }
+    subject {
+      post :create,
+      params: { post_id: post_instance.id, comment: attributes_for(:comment) }
+    }
+
+    context 'ログインしている場合' do
+      before do
+        sign_in user
+      end
+
+      context '有効な属性値の場合' do
+        it 'コメントを追加できること' do
+          expect { subject }.to change(user.comments, :count).by(1)
+        end
+      end
+
+      context '無効な属性値の場合' do
+        it 'コメントを追加できないこと' do
+          expect {
+            post :create,
+            params: {
+              post_id: post_instance.id,
+              comment: attributes_for(:comment, :text_invalid)
+            }
+          }.to_not change(user.comments, :count)
+        end
+      end
+    end
+
+    context 'ログインしていない場合' do
+      it '302レスポンスを返すこと' do
+        subject
+        expect(response.status).to eq 302
+      end
+
+      it 'ログイン画面にリダイレクトされること' do
+        subject
+        expect(response).to redirect_to '/users/sign_in'
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.raise_errors_for_deprecations!
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## What
- commentコントローラの単体テストに実装
- 適切に保存できているかを主にテストしていて、適切なテンプレートを返しているかなどは上層のrequest specに委ねる

## Why
- comment controllerのテストをすることでcommentのロジックの信頼性を向上させるため